### PR TITLE
Proxy keyboard events to iframes

### DIFF
--- a/xrpackage.js
+++ b/xrpackage.js
@@ -319,14 +319,14 @@ const xrTypeAdders = {
     });
 
     function emitKeyboardEvent(e) {
-      p.context.iframe.contentWindow.dispatchEvent(new KeyboardEvent(e.type, e))
+      p.context.iframe.contentWindow.dispatchEvent(new KeyboardEvent(e.type, e));
     }
 
-    p.context.emitKeyboardEvent = emitKeyboardEvent
+    p.context.emitKeyboardEvent = emitKeyboardEvent;
 
-    window.addEventListener('keydown', emitKeyboardEvent, true)
-    window.addEventListener('keyup', emitKeyboardEvent, true)
-    window.addEventListener('keypress', emitKeyboardEvent, true)
+    window.addEventListener('keydown', emitKeyboardEvent, true);
+    window.addEventListener('keyup', emitKeyboardEvent, true);
+    window.addEventListener('keypress', emitKeyboardEvent, true);
 
     p.matrixWorldNeedsUpdate = true;
 
@@ -366,11 +366,11 @@ const xrTypeRemovers = {
       return rafPackage !== p;
     });
 
-    const emitKeyboardEvent = p.context.emitKeyboardEvent
+    const emitKeyboardEvent = p.context.emitKeyboardEvent;
 
-    window.removeEventListener('keydown', emitKeyboardEvent, true)
-    window.removeEventListener('keyup', emitKeyboardEvent, true)
-    window.removeEventListener('keypress', emitKeyboardEvent, true)
+    window.removeEventListener('keydown', emitKeyboardEvent, true);
+    window.removeEventListener('keyup', emitKeyboardEvent, true);
+    window.removeEventListener('keypress', emitKeyboardEvent, true);
 
     p.context.iframe && p.context.iframe.parentNode.removeChild(p.context.iframe);
   },

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -317,10 +317,21 @@ const xrTypeAdders = {
       p.context.iframe.addEventListener('load', accept);
       p.context.iframe.addEventListener('error', reject);
     });
+
+    function emitKeyboardEvent(e) {
+      p.context.iframe.contentWindow.dispatchEvent(new KeyboardEvent(e.type, e))
+    }
+
+    p.context.emitKeyboardEvent = emitKeyboardEvent
+
+    window.addEventListener('keydown', emitKeyboardEvent, true)
+    window.addEventListener('keyup', emitKeyboardEvent, true)
+    window.addEventListener('keypress', emitKeyboardEvent, true)
+
     p.matrixWorldNeedsUpdate = true;
-    
+
     p.context.requestPresentPromise = makePromise();
-    
+
     const d = p.getMainData();
     const indexHtml = d.toString('utf8');
     await p.context.iframe.contentWindow.xrpackage.iframeInit({
@@ -354,6 +365,12 @@ const xrTypeRemovers = {
       const rafPackage = this.packages.find(p => p.context.iframe && p.context.iframe.contentWindow === rafWindow);
       return rafPackage !== p;
     });
+
+    const emitKeyboardEvent = p.context.emitKeyboardEvent
+
+    window.removeEventListener('keydown', emitKeyboardEvent, true)
+    window.removeEventListener('keyup', emitKeyboardEvent, true)
+    window.removeEventListener('keypress', emitKeyboardEvent, true)
 
     p.context.iframe && p.context.iframe.parentNode.removeChild(p.context.iframe);
   },


### PR DESCRIPTION
How's this look? I think it'd be better to do the workers in a separate PR after I play around with it a little.

Also, where should I add docs for stuff like this? Should I maybe add this to the gotchas near the end of the README? Something like "You can get keyboard events, but only on the `window` object".