### PR TITLE
Fix A-Frame/three.js from Supermedium

### DIFF
--- a/xrpackage/Graphics.js
+++ b/xrpackage/Graphics.js
@@ -249,6 +249,9 @@ ProxiedWebGLRenderingContext.prototype.getExtension = (_getExtension => function
     'EXT_disjoint_timer_query',
     'EXT_disjoint_timer_query_webgl2',
     'KHR_parallel_shader_compile',
+    'OES_texture_float_linear',
+    'OES_texture_float extension',
+    'EXT_color_buffer_float',
   ].includes(name)) {
     return this.canvas.proxyContext.getExtension(name);
   } else {

--- a/xrpackage/Graphics.js
+++ b/xrpackage/Graphics.js
@@ -254,8 +254,21 @@ ProxiedWebGLRenderingContext.prototype.getExtension = (_getExtension => function
     'EXT_color_buffer_float',
   ].includes(name)) {
     return this.canvas.proxyContext.getExtension(name);
-  } else {
+  } else if ([ // implicit in WebGL2
+    'OES_texture_float',
+    'OES_texture_half_float',
+    'OES_texture_half_float_linear',
+    'WEBGL_depth_texture',
+    'OES_standard_derivatives',
+    'OES_element_index_uint',
+    'EXT_blend_minmax',
+    'EXT_frag_depth',
+    'WEBGL_draw_buffers',
+    'EXT_shader_texture_lod',
+  ].includes(name)) {
     return {};
+  } else {
+    return null;
   }
 })(ProxiedWebGLRenderingContext.prototype.getExtension);
 ProxiedWebGLRenderingContext.prototype.enable = (oldEnable => function enable(flag) {


### PR DESCRIPTION
A-Frame uses a fork of THREE.js that supports [multiview rendering](https://developer.mozilla.org/en-US/docs/Web/API/OVR_multiview2).

However in our framebuffer implementation we currently do not support that -- this is why version of A-Frame based on THREE.js that support multiview did not work with XRPackage.

This fix addresses that issue by signalling that we do not support the multiview extension even if the browser does indeed support it.

This is implemented by whitelisting WebGL extensions instead of returning support for any unknown extension, which we were doing before. We might need to add more extensions to this list if other apps are using them.