### PR TITLE
Subrender (mirror) support

### DIFF
--- a/xrpackage/iframe.html
+++ b/xrpackage/iframe.html
@@ -154,6 +154,9 @@ class XRPackageManager extends EventTarget {
   remove(p) {
     return this._engine.remove(p);
   }
+  render(width, height, viewMatrix, projectionMatrix, framebuffer) {
+    return this._engine.render(this._package, width, height, viewMatrix, projectionMatrix, framebuffer);
+  }
   setMatrix(matrixArray) {
     this.xrOffsetMatrix.fromArray(matrixArray);
   }

--- a/xrpackage/three.module.js
+++ b/xrpackage/three.module.js
@@ -23446,8 +23446,7 @@ function WebXRManager( renderer, gl ) {
 
 	var onAnimationFrameCallback = null;
 
-	function onAnimationFrame( time, frame ) {
-
+    function preAnimationFrame(time, frame) {
 		pose = frame.getViewerPose( referenceSpace );
 
 		if ( pose !== null ) {
@@ -23506,6 +23505,12 @@ function WebXRManager( renderer, gl ) {
 			controller.update( inputSource, frame, referenceSpace );
 
 		}
+    }
+    this.preAnimationFrame = preAnimationFrame;
+
+	function onAnimationFrame( time, frame ) {
+
+		preAnimationFrame(time, frame);
 
 		if ( onAnimationFrameCallback ) onAnimationFrameCallback( time, frame );
 


### PR DESCRIPTION
This PR adds an API for sub-rendering of the main XR engine package loop.

This basically lets you implement mirrors against other WebXR apps, even if they are in a different context. The main use case is mirror packages.

![lol13](https://user-images.githubusercontent.com/6926057/85083607-39c02980-b1a0-11ea-9d7d-7064409bf2e0.gif)

The api is (inside a package):

```
xrpackage.render(width, height, viewMatrix, projectionMatrix, webglFramebuffer);
```

... which will perform a synchronous render of all of the packages that are queued for that frame.

Note two limitations:

- it is monocular
- it currently must be done inside of an existing `session.requestAnimationFrame` or it will not work