### PR TITLE
Nesting support

### DIFF
--- a/xrpackage.js
+++ b/xrpackage.js
@@ -1855,13 +1855,13 @@ export class XRPackage extends EventTarget {
       this.context.iframe && this.context.iframe.contentWindow.xrpackage.sendEvent(name, value);
     }
   }
-  async reload() {
+  /* async reload() {
     const {parent} = this;
     if (parent) {
       parent.remove(this, 'reload');
       await parent.add(this, 'reload');
     }
-  }
+  } */
   getManifestJson() {
     const manifestJsonFile = this.files.find(file => new URL(file.url).pathname === '/manifest.json');
     if (manifestJsonFile) {

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -1302,9 +1302,9 @@ export class XRPackageEngine extends XRNode {
     }
   }
   updateMatrixWorld() {
-    for (const p of this.children) {
+    this.recurseChildren(p => {
       p.updateMatrixWorld();
-    }
+    });
   }
   draw(timestamp = performance.now(), skipPackage = null) {
     // update matrices
@@ -2189,9 +2189,9 @@ export class XRPackage extends XRNode {
       this.context.iframe && this.context.iframe.contentWindow && this.context.iframe.contentWindow.xrpackage &&
         this.context.iframe.contentWindow.xrpackage.setMatrix(this.matrixWorld.toArray(localArray));
 
-      for (const p of this.children) {
+      this.recurseChildren(p => {
         p.updateMatrixWorld(true);
-      }
+      });
     }
   }
   grabrelease() {

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -2236,6 +2236,7 @@ export class XRPackage extends XRNode {
         });
         this.context.object = new THREE.Object3D();
         this.context.object.add(this.context.rig.model);
+        this.name = 'Default avatar';
         this.type = 'vrm@0.0.1';
       }
       this.context.rig.setMicrophoneMediaStream = _setMicrophoneMediaStream(this.context.rig.setMicrophoneMediaStream);

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -1044,13 +1044,12 @@ export class XRPackageEngine extends XRNode {
   }
   setXrFramebuffer(xrfb) {
     this.fakeSession.xrFramebuffer = xrfb;
-    for (let i = 0; i < this.children.length; i++) {
-      this.children[i].setXrFramebuffer(xrfb);
-    }
+    this.recurseChildren(p => {
+      p.setXrFramebuffer(xrfb);
+    });
   }
   setClearFreeFramebuffer(fb) {
-    for (let i = 0; i < this.children.length; i++) {
-      const p = this.children[i];
+    this.recurseChildren(p => {
       if (
         // p !== skipPackage &&
         p.context.iframe && p.context.iframe.contentWindow && p.context.iframe.contentWindow.xrpackage && p.context.iframe.contentWindow.xrpackage.session && p.context.iframe.contentWindow.xrpackage.session.renderState.baseLayer
@@ -1058,7 +1057,7 @@ export class XRPackageEngine extends XRNode {
         // p.context.iframe.contentWindow.xrpackage.session.renderState.baseLayer.context._exokitClearEnabled(false);
         p.context.iframe.contentWindow.xrpackage.session.renderState.baseLayer.context._exokitSetXrFramebuffer(fb);
       }
-    }
+    });
   }
   tick(timestamp = performance.now(), frame = null) {
     this.renderer.clear(true, true, true);

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -545,6 +545,7 @@ export class XRPackageEngine extends EventTarget {
     this.xrState.renderWidth[0] = options.width / 2 * options.devicePixelRatio;
     this.xrState.renderHeight[0] = options.height * options.devicePixelRatio;
     this.matrix = new THREE.Matrix4();
+    this.matrixWorld = this.matrix;
 
     this.name = 'XRPackage Scene';
     this.packages = [];
@@ -1705,6 +1706,7 @@ export class XRPackage extends EventTarget {
     this.details = {};
 
     this.matrix = a instanceof XRPackage ? a.matrix.clone() : new THREE.Matrix4();
+    this.matrixWorld = a instanceof XRPackage ? a.matrixWorld.clone() : new THREE.Matrix4();
     this.matrixWorldNeedsUpdate = true;
     this._visible = true;
     this.running = false;
@@ -2143,15 +2145,16 @@ export class XRPackage extends EventTarget {
     if (this.matrixWorldNeedsUpdate) {
       this.matrixWorldNeedsUpdate = false;
 
-      localMatrix
-        .copy(this.matrix)
-        .premultiply(this.parent.matrix);
+      this.matrixWorld
+        .copy(this.parent.matrixWorld)
+        .multiply(this.matrix);
 
       this.context.object &&
         this.context.object.matrix
           .copy(this.matrix)
           .decompose(this.context.object.position, this.context.object.quaternion, this.context.object.scale);
-      this.context.iframe && this.context.iframe.contentWindow && this.context.iframe.contentWindow.xrpackage && this.context.iframe.contentWindow.xrpackage.setMatrix(localMatrix.toArray(localArray));
+      this.context.iframe && this.context.iframe.contentWindow && this.context.iframe.contentWindow.xrpackage &&
+        this.context.iframe.contentWindow.xrpackage.setMatrix(this.matrixWorld.toArray(localArray));
     }
   }
   grabrelease() {

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -535,11 +535,17 @@ class XRNode extends EventTarget {
       }));
 
       setTimeout(() => {
-        p.ensureRunStop();
+        p.recurse(p => {
+          p.ensureRunStop();
+        });
       });
     } else {
       throw new Error('package is not a child of this node');
     }
+  }
+  recurse(fn) {
+    fn(this);
+    this.recurseChildren(fn);
   }
   recurseChildren(fn) {
     for (const p of this.children) {

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -1676,7 +1676,7 @@ export class XRPackageEngine extends XRNode {
   }
 }
 
-let packageIds = 0;
+let packageIds = Math.floor(Math.random() * 0xFFFFFF);
 export class XRPackage extends XRNode {
   constructor(a) {
     super();

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -831,7 +831,7 @@ export class XRPackageEngine extends EventTarget {
         p.ensureRunStop();
       });
     } else {
-      throw new Error(`unknown xr_type: ${type}`);
+      throw new Error('package is not a child of this node');
     }
   }
   setMatrix(m) {

--- a/xrpackage.js
+++ b/xrpackage.js
@@ -1832,13 +1832,16 @@ export class XRPackage extends EventTarget {
       o.visible = visible;
     }
   }
-  isAttached() {
+  getParentEngine() {
     for (let p = this; !!p; p = p.parent) {
       if (p instanceof XRPackageEngine) {
-        return true;
+        return p;
       }
     }
-    return false;
+    return null;
+  }
+  isAttached() {
+    return this.getParentEngine() !== null;
   }
   async getHash() {
     if (this.hash === null) {
@@ -2152,15 +2155,16 @@ export class XRPackage extends EventTarget {
     }
   }
   grabrelease() {
-    if (this.parent) {
-      for (const k in this.parent.grabs) {
-        if (this.parent.grabs[k] === this) {
-          this.parent.grabs[k] = null;
+    const engine = this.getParentEngine();
+    if (engine) {
+      for (const k in engine.grabs) {
+        if (engine.grabs[k] === this) {
+          engine.grabs[k] = null;
         }
       }
-      for (const k in this.parent.equips) {
-        if (this.parent.equips[k] === this) {
-          this.parent.equips[k] = null;
+      for (const k in engine.equips) {
+        if (engine.equips[k] === this) {
+          engine.equips[k] = null;
         }
       }
     }

--- a/xrpackage/iframe.html
+++ b/xrpackage/iframe.html
@@ -152,6 +152,9 @@ class XRPackageManager extends EventTarget {
   get package() {
     return this._package;
   }
+  get children() {
+    return this._package.children.slice();
+  }
   add(p) {
     return this._engine.add(p);
   }

--- a/xrpackage/iframe.html
+++ b/xrpackage/iframe.html
@@ -53,7 +53,7 @@ class XRPackageManager extends EventTarget {
 
     this.xrState = xrState;
 
-    window.requestAnimationFrame = fn => engine.packageRequestAnimationFrame(fn, globalThis, 0);
+    window.requestAnimationFrame = fn => engine.packageRequestAnimationFrame(fn, globalThis, pkg, 0);
     window.cancelAnimationFrame = engine.packageCancelAnimationFrame.bind(engine);
     
     hijackCanvas(context);
@@ -64,7 +64,7 @@ class XRPackageManager extends EventTarget {
     window.WebGL2RenderingContext = WebGL2RenderingContext;
 
     const session = new XR.XRSession(this.xrState, this.xrOffsetMatrix);
-    session.onrequestanimationframe = fn => engine.packageRequestAnimationFrame(fn, globalThis, 0);
+    session.onrequestanimationframe = fn => engine.packageRequestAnimationFrame(fn, globalThis, pkg, 0);
     session.oncancelanimationframe = engine.packageCancelAnimationFrame.bind(engine);
     this.session = session;
 

--- a/xrpackage/iframe.html
+++ b/xrpackage/iframe.html
@@ -156,10 +156,10 @@ class XRPackageManager extends EventTarget {
     return this._package.children.slice();
   }
   add(p) {
-    return this._engine.add(p);
+    return this._package.add(p);
   }
   remove(p) {
-    return this._engine.remove(p);
+    return this._package.remove(p);
   }
   render(width, height, viewMatrix, projectionMatrix, framebuffer) {
     return this._engine.render(this._package, width, height, viewMatrix, projectionMatrix, framebuffer);

--- a/xrpackage/symbols.js
+++ b/xrpackage/symbols.js
@@ -1,5 +1,6 @@
 const module = {exports: {}};
 module.exports.windowSymbol = Symbol('windowSymbol');
+module.exports.packageSymbol = Symbol('packageSymbol');
 module.exports.addRunSymbol = Symbol('addRunSymbol');
 module.exports.computedStyleSymbol = Symbol('computedStyleSymbol');
 module.exports.disabledEventsSymbol = Symbol('disabledEventsSymbol');


### PR DESCRIPTION
This PR adds support for nested XRPackages.

Basically, that means we have `add` and `remove` methods not only on the `XRPackageEngine` but on `XRPackage` as well, with a recursive matrix transform scene graph managing parent-child relationships.

The internal `iframe` of XRPackages is also updated to reflect this new reality -- `add` and `remove` in the iframe context are local, allowing a parent to add/remove only its own children.

This was needed for nested multiplayer support.

![lol17](https://user-images.githubusercontent.com/6926057/85631322-4f6f9c00-b643-11ea-9d81-21416cd9910c.gif)
