### PR TITLE
Add floor height support

### DIFF
--- a/xrpackage/avatars/avatars.js
+++ b/xrpackage/avatars/avatars.js
@@ -1096,6 +1096,10 @@ class Avatar {
     }
   }
 
+  setFloorHeight(floorHeight) {
+    this.poseManager.vrTransforms.floorHeight = floorHeight;
+  }
+
   destroy() {
     this.setMicrophoneMediaStream(null);
   }

--- a/xrpackage/avatars/vrarmik/LegsManager.js
+++ b/xrpackage/avatars/vrarmik/LegsManager.js
@@ -151,7 +151,7 @@ class Leg {
 
 	getStandFactor() {
 		return 1 - Math.pow(Math.min(Math.max(
-			(Helpers.getWorldPosition(this.legsManager.rig.shoulderTransforms.eyes, localVector).add(this.eyesToUpperLegOffset).y - this.legLength) / (this.legsManager.rig.height*0.2),
+			(Helpers.getWorldPosition(this.legsManager.rig.shoulderTransforms.eyes, localVector).add(this.eyesToUpperLegOffset).y - this.legsManager.poseManager.vrTransforms.floorHeight - this.legLength) / (this.legsManager.rig.height*0.2),
 		0), 1), 0.7);
 	}
 }
@@ -222,7 +222,7 @@ class LegsManager {
 	  }
 
     const hipsFloorPosition = localVector.copy(this.hips.position);
-    hipsFloorPosition.y = 0;
+    hipsFloorPosition.y = this.poseManager.vrTransforms.floorHeight;
     const hipsFloorEuler = localEuler.setFromQuaternion(this.hips.quaternion, 'YXZ');
     hipsFloorEuler.x = 0;
     hipsFloorEuler.z = 0;
@@ -388,7 +388,7 @@ class LegsManager {
     if (this.rig.shoulderTransforms.prone) {
     	const targetPosition = Helpers.getWorldPosition(this.leftLeg.upperLeg, localVector6)
         .add(
-        	localVector7.set(0, -this.leftLeg.legLength*0.95, 0)
+        	localVector7.set(0, -this.leftLeg.legLength*0.95 + this.poseManager.vrTransforms.floorHeight, 0)
         	  .applyQuaternion(this.hips.quaternion)
         );
       targetPosition.y = 0;
@@ -414,13 +414,13 @@ class LegsManager {
       this.leftLeg.foot.stickTransform.position.lerp(targetPosition, 0.1);
 		} else {
 			const targetPosition = localVector6.copy(this.leftLeg.foot.stickTransform.position);
-			targetPosition.y = 0;
+			targetPosition.y = this.poseManager.vrTransforms.floorHeight;
 			this.leftLeg.foot.stickTransform.position.lerp(targetPosition, 0.2);
 		}
 		if (this.rig.shoulderTransforms.prone) {
     	const targetPosition = Helpers.getWorldPosition(this.rightLeg.upperLeg, localVector6)
         .add(
-        	localVector7.set(0, -this.rightLeg.legLength*0.95, 0)
+        	localVector7.set(0, -this.rightLeg.legLength*0.95 + this.poseManager.vrTransforms.floorHeight, 0)
         	  .applyQuaternion(this.hips.quaternion)
         );
       targetPosition.y = 0;
@@ -447,7 +447,7 @@ class LegsManager {
       this.rightLeg.foot.stickTransform.position.lerp(targetPosition, 0.1);
 		} else {
 			const targetPosition = localVector6.copy(this.rightLeg.foot.stickTransform.position);
-			targetPosition.y = 0;
+			targetPosition.y = this.poseManager.vrTransforms.floorHeight;
 			this.rightLeg.foot.stickTransform.position.lerp(targetPosition, 0.2);
 		}
 

--- a/xrpackage/avatars/vrarmik/ShoulderPoser.js
+++ b/xrpackage/avatars/vrarmik/ShoulderPoser.js
@@ -356,7 +356,7 @@ class ShoulderPoser
 		}
 
 		getProneFactor() {
-      return 1 - Math.min(Math.max((this.vrTransforms.head.position.y - this.rig.height*0.3)/(this.rig.height*0.3), 0), 1);
+          return 1 - Math.min(Math.max((this.vrTransforms.head.position.y - this.vrTransforms.floorHeight - this.rig.height*0.3)/(this.rig.height*0.3), 0), 1);
 		}
 
 		/* detectHandsBehindHead(targetRotation)

--- a/xrpackage/avatars/vrarmik/VRTrackingReferences.js
+++ b/xrpackage/avatars/vrarmik/VRTrackingReferences.js
@@ -15,6 +15,7 @@ class VRTrackingReferences {
     this.rightHand = new THREE.Object3D();
     this.rightHand.pointer = 0;
     this.rightHand.grip = 0;
+    this.floorHeight = 0;
     /* this.head.onchange = () => {
       console.log('change 2', new Error().stack);
     }; */


### PR DESCRIPTION
This PR adds the `setFloorHeight` avatars method, which allows setting the floor height against which the avatar inverse kinematics will be tested.