### PR TITLE
Add tests for collision mesh existence 

### DIFF
--- a/tests/get-collision-mesh.js
+++ b/tests/get-collision-mesh.js
@@ -1,0 +1,23 @@
+/* global XRPackage, XRPackageEngine */
+const test = require('ava');
+
+const withPageAndStaticServer = require('./utils/_withPageAndStaticServer');
+
+test('get collision mesh of baked wbn - should exist', withPageAndStaticServer, async (t, page) => {
+  const response = await page.evaluate(pageFunction, `${t.context.staticUrl}/assets/baked-xrpk.wbn`);
+  t.true(response);
+});
+
+test('get collision mesh of unbaked wbn - should not exist', withPageAndStaticServer, async (t, page) => {
+  const response = await page.evaluate(pageFunction, `${t.context.staticUrl}/assets/unbaked-xrpk.wbn`);
+  t.false(response);
+});
+
+const pageFunction = async path => {
+  const file = await fetch(path).then(res => res.arrayBuffer());
+  const p = new XRPackage(file);
+  await p.waitForLoad();
+
+  const mesh = await p.getVolumeMesh();
+  return mesh !== null;
+};


### PR DESCRIPTION
This change adds tests to see if a collision mesh exists within in package. 

Maybe checking for mesh existence is sufficient, or should the validity of the mesh be tested as well? 