### PR TITLE
Catch puppeteer evaluate errors for test suite

### DIFF
--- a/tests/compile-from-file.js
+++ b/tests/compile-from-file.js
@@ -48,18 +48,20 @@ const performTest = async (t, page, assetPath, mime) => {
 };
 
 const pageFunction = async path => {
-  const blob = await fetch(path).then(res => res.blob());
-  blob.name = path.split('/').pop();
+  return window.safeEvaluate(async () => {
+    const blob = await fetch(path).then(res => res.blob());
+    blob.name = path.split('/').pop();
 
-  const uint8Array = await XRPackage.compileFromFile(blob);
-  const uint8ArrayToBase64 = async uint8Array => new Promise(resolve => {
-    const blob = new Blob([uint8Array]);
-    const reader = new FileReader();
-    reader.onload = event => resolve(event.target.result.replace(/data:.*base64,/, ''));
-    reader.readAsDataURL(blob);
+    const uint8Array = await XRPackage.compileFromFile(blob);
+    const uint8ArrayToBase64 = async uint8Array => new Promise(resolve => {
+      const blob = new Blob([uint8Array]);
+      const reader = new FileReader();
+      reader.onload = event => resolve(event.target.result.replace(/data:.*base64,/, ''));
+      reader.readAsDataURL(blob);
+    });
+
+    // Puppeteer only supports passing serializable data to/from Node
+    const base64 = await uint8ArrayToBase64(uint8Array);
+    return base64;
   });
-
-  // Puppeteer only supports passing serializable data to/from Node
-  const base64 = await uint8ArrayToBase64(uint8Array);
-  return base64;
 };

--- a/tests/download-upload-package.js
+++ b/tests/download-upload-package.js
@@ -1,3 +1,4 @@
+/* global XRPackage */
 const test = require('ava');
 
 const withPageAndStaticServer = require('./utils/_withPageAndStaticServer');
@@ -14,13 +15,17 @@ test('upload package programmatically', withPageAndStaticServer, async (t, page)
 });
 
 const downloadFunction = async (hash) => {
-  const p = await XRPackage.download(hash);
-  return p.hash === hash;
+  return window.safeEvaluate(async () => {
+    const p = await XRPackage.download(hash);
+    return p.hash === hash;
+  });
 };
 
 const uploadFunction = async (path) => {
-  const file = await fetch(path).then(res => res.arrayBuffer());
-  const p = new XRPackage(file);
-  const hash = await p.upload();
-  return hash === p.hash;
+  return window.safeEvaluate(async () => {
+    const file = await fetch(path).then(res => res.arrayBuffer());
+    const p = new XRPackage(file);
+    const hash = await p.upload();
+    return hash === p.hash;
+  });
 };

--- a/tests/loading-screenshot.js
+++ b/tests/loading-screenshot.js
@@ -14,9 +14,11 @@ test('load screenshot of unbaked xrpk', withPageAndStaticServer, async (t, page)
 });
 
 const pageFunction = async path => {
-  const file = await fetch(path).then(res => res.arrayBuffer());
-  const p = new XRPackage(file);
-  await p.waitForLoad();
-  const screenshot = await p.getScreenshotImage();
-  return screenshot ? screenshot.outerHTML : null;
+  return window.safeEvaluate(async () => {
+    const file = await fetch(path).then(res => res.arrayBuffer());
+    const p = new XRPackage(file);
+    await p.waitForLoad();
+    const screenshot = await p.getScreenshotImage();
+    return screenshot ? screenshot.outerHTML : null;
+  });
 };

--- a/tests/utils/_withPageAndStaticServer.js
+++ b/tests/utils/_withPageAndStaticServer.js
@@ -48,9 +48,9 @@ module.exports = async (t, run) => {
 
     // Expose safeEvaluate function to try...catch page functions for better stack traces
     await page.evaluate(() => {
-      window.safeEvaluate = async function(fn, ...args) {
+      window.safeEvaluate = async function(fn) {
         try {
-          return await fn(...args);
+          return await fn();
         } catch (err) {
           console.error(err.stack);
           return null;

--- a/tests/utils/_withPageAndStaticServer.js
+++ b/tests/utils/_withPageAndStaticServer.js
@@ -34,7 +34,9 @@ module.exports = async (t, run) => {
     args: ['--no-sandbox'],
   });
   const page = await browser.newPage();
-  page.on('console', consoleObj => console.log(`Page log: "${consoleObj.text()}"`));
+  page.on('console', consoleObj => console.log('Page log:', consoleObj.text()));
+  page.on('pageerror', err => console.error('Page error: ', err.stack));
+  page.on('requestfailed', req => console.error('Request failed: ', req));
 
   const server = _newStaticServer();
   const port = server.address().port;
@@ -43,6 +45,19 @@ module.exports = async (t, run) => {
   try {
     // Wait for no more network requests for at least 500ms before passing onto main test
     await page.goto(t.context.staticUrl, {waitUntil: 'networkidle0'});
+
+    // Expose safeEvaluate function to try...catch page functions for better stack traces
+    await page.evaluate(() => {
+      window.safeEvaluate = async function(fn, ...args) {
+        try {
+          return await fn(...args);
+        } catch (err) {
+          console.error(err.stack);
+          return null;
+        }
+      };
+    });
+
     await run(t, page);
   } finally {
     server.close();

--- a/tests/wear-avatar.js
+++ b/tests/wear-avatar.js
@@ -9,10 +9,12 @@ test('wear package as avatar function', withPageAndStaticServer, async (t, page)
 });
 
 const pageFunction = async path => {
-  const file = await fetch(path).then(res => res.arrayBuffer());
-  const p = new XRPackage(file);
-  await p.waitForLoad();
-  const engine = new XRPackageEngine();
-  await engine.wearAvatar(p);
-  return engine.rig !== null;
+  return window.safeEvaluate(async () => {
+    const file = await fetch(path).then(res => res.arrayBuffer());
+    const p = new XRPackage(file);
+    await p.waitForLoad();
+    const engine = new XRPackageEngine();
+    await engine.wearAvatar(p);
+    return engine.rig !== null;
+  });
 };


### PR DESCRIPTION
This PR essentially wraps all the page functions used in the test suite around a try..catch so we can log the stack trace for errors in tests, making it easier to debug them.

To do this, it adds a `safeEvaluate` function to `window` which the page functions are now wrapped with, which just saves us from having to write the `try... catch` block for every single page function in each test.