### PR TITLE
Filter Puppeteer browser stdout and stderr in tests to log all console output

### DIFF
--- a/tests/compile-from-file.js
+++ b/tests/compile-from-file.js
@@ -53,20 +53,18 @@ const performTest = async (t, page, assetPath, mime) => {
 };
 
 const pageFunction = async path => {
-  return window.safeEvaluate(async () => {
-    const blob = await fetch(path).then(res => res.blob());
-    blob.name = path.split('/').pop();
+  const blob = await fetch(path).then(res => res.blob());
+  blob.name = path.split('/').pop();
 
-    const uint8Array = await XRPackage.compileFromFile(blob);
-    const uint8ArrayToBase64 = async uint8Array => new Promise(resolve => {
-      const blob = new Blob([uint8Array]);
-      const reader = new FileReader();
-      reader.onload = event => resolve(event.target.result.replace(/data:.*base64,/, ''));
-      reader.readAsDataURL(blob);
-    });
-
-    // Puppeteer only supports passing serializable data to/from Node
-    const base64 = await uint8ArrayToBase64(uint8Array);
-    return base64;
+  const uint8Array = await XRPackage.compileFromFile(blob);
+  const uint8ArrayToBase64 = async uint8Array => new Promise(resolve => {
+    const blob = new Blob([uint8Array]);
+    const reader = new FileReader();
+    reader.onload = event => resolve(event.target.result.replace(/data:.*base64,/, ''));
+    reader.readAsDataURL(blob);
   });
+
+  // Puppeteer only supports passing serializable data to/from Node
+  const base64 = await uint8ArrayToBase64(uint8Array);
+  return base64;
 };

--- a/tests/download-upload-package.js
+++ b/tests/download-upload-package.js
@@ -1,4 +1,3 @@
-/* global XRPackage */
 const test = require('ava');
 
 const withPageAndStaticServer = require('./utils/_withPageAndStaticServer');
@@ -15,17 +14,13 @@ test('upload package programmatically', withPageAndStaticServer, async (t, page)
 });
 
 const downloadFunction = async (hash) => {
-  return window.safeEvaluate(async () => {
-    const p = await XRPackage.download(hash);
-    return p.hash === hash;
-  });
+  const p = await XRPackage.download(hash);
+  return p.hash === hash;
 };
 
 const uploadFunction = async (path) => {
-  return window.safeEvaluate(async () => {
-    const file = await fetch(path).then(res => res.arrayBuffer());
-    const p = new XRPackage(file);
-    const hash = await p.upload();
-    return hash === p.hash;
-  });
+  const file = await fetch(path).then(res => res.arrayBuffer());
+  const p = new XRPackage(file);
+  const hash = await p.upload();
+  return hash === p.hash;
 };

--- a/tests/loading-screenshot.js
+++ b/tests/loading-screenshot.js
@@ -14,11 +14,9 @@ test('load screenshot of unbaked xrpk', withPageAndStaticServer, async (t, page)
 });
 
 const pageFunction = async path => {
-  return window.safeEvaluate(async () => {
-    const file = await fetch(path).then(res => res.arrayBuffer());
-    const p = new XRPackage(file);
-    await p.waitForLoad();
-    const screenshot = await p.getScreenshotImage();
-    return screenshot ? screenshot.outerHTML : null;
-  });
+  const file = await fetch(path).then(res => res.arrayBuffer());
+  const p = new XRPackage(file);
+  await p.waitForLoad();
+  const screenshot = await p.getScreenshotImage();
+  return screenshot ? screenshot.outerHTML : null;
 };

--- a/tests/utils/_withPageAndStaticServer.js
+++ b/tests/utils/_withPageAndStaticServer.js
@@ -34,9 +34,7 @@ module.exports = async (t, run) => {
     args: ['--no-sandbox'],
   });
   const page = await browser.newPage();
-  page.on('console', consoleObj => console.log('Page log:', consoleObj.text()));
-  page.on('pageerror', err => console.error('Page error: ', err.stack));
-  page.on('requestfailed', req => console.error('Request failed: ', req));
+  page.on('console', consoleObj => console.log(`Page log: "${consoleObj.text()}"`));
 
   const server = _newStaticServer();
   const port = server.address().port;
@@ -45,19 +43,6 @@ module.exports = async (t, run) => {
   try {
     // Wait for no more network requests for at least 500ms before passing onto main test
     await page.goto(t.context.staticUrl, {waitUntil: 'networkidle0'});
-
-    // Expose safeEvaluate function to try...catch page functions for better stack traces
-    await page.evaluate(() => {
-      window.safeEvaluate = async function(fn) {
-        try {
-          return await fn();
-        } catch (err) {
-          console.error(err.stack);
-          return null;
-        }
-      };
-    });
-
     await run(t, page);
   } finally {
     server.close();

--- a/tests/utils/_withPageAndStaticServer.js
+++ b/tests/utils/_withPageAndStaticServer.js
@@ -33,8 +33,19 @@ module.exports = async (t, run) => {
     devtools: true,
     args: ['--no-sandbox'],
   });
-  browser.process().stdout.pipe(process.stdout);
-  browser.process().stderr.pipe(process.stderr);
+
+  browser.process().stdout.on('data', d => {
+    if (d.includes(':CONSOLE')) {
+      console.log(d.toString());
+    }
+  });
+
+  browser.process().stderr.on('data', d => {
+    if (d.includes(':CONSOLE')) {
+      console.error(d.toString());
+    }
+  });
+
   const page = await browser.newPage();
   page.on('requestfailed', req => console.error('Request failed: ', req));
 

--- a/tests/utils/_withPageAndStaticServer.js
+++ b/tests/utils/_withPageAndStaticServer.js
@@ -31,10 +31,11 @@ module.exports = async (t, run) => {
   const browser = await puppeteer.launch({
     headless: true,
     devtools: true,
+    dumpio: true,
     args: ['--no-sandbox'],
   });
   const page = await browser.newPage();
-  page.on('console', consoleObj => console.log(`Page log: "${consoleObj.text()}"`));
+  page.on('requestfailed', req => console.error('Request failed: ', req));
 
   const server = _newStaticServer();
   const port = server.address().port;

--- a/tests/utils/_withPageAndStaticServer.js
+++ b/tests/utils/_withPageAndStaticServer.js
@@ -31,9 +31,10 @@ module.exports = async (t, run) => {
   const browser = await puppeteer.launch({
     headless: true,
     devtools: true,
-    dumpio: true,
     args: ['--no-sandbox'],
   });
+  browser.process().stdout.pipe(process.stdout);
+  browser.process().stderr.pipe(process.stderr);
   const page = await browser.newPage();
   page.on('requestfailed', req => console.error('Request failed: ', req));
 

--- a/tests/wear-avatar.js
+++ b/tests/wear-avatar.js
@@ -9,12 +9,10 @@ test('wear package as avatar function', withPageAndStaticServer, async (t, page)
 });
 
 const pageFunction = async path => {
-  return window.safeEvaluate(async () => {
-    const file = await fetch(path).then(res => res.arrayBuffer());
-    const p = new XRPackage(file);
-    await p.waitForLoad();
-    const engine = new XRPackageEngine();
-    await engine.wearAvatar(p);
-    return engine.rig !== null;
-  });
+  const file = await fetch(path).then(res => res.arrayBuffer());
+  const p = new XRPackage(file);
+  await p.waitForLoad();
+  const engine = new XRPackageEngine();
+  await engine.wearAvatar(p);
+  return engine.rig !== null;
 };


### PR DESCRIPTION
This reverts the changes made in #110, and instead uses browser's process `stdout` and `stderr` streams to filter the logs output to the console.

I tried to use the `dumpio` flag to automatically log everything to the Node process, but [it looks like it contains internal browser logs](https://github.com/webaverse/xrpackage/runs/944820101#step:6:19) that make it a bit confusing.

Part of #115.